### PR TITLE
fix: point types field at published declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:lint:fix": "eslint --fix",
     "prepare": "husky"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

This updates the top-level package `types` field to point at the published declaration entry in `dist`.

## Why

The published `@duplojs/zod-accelerator@2.6.2` package declares:

```json
"types": "./types/index.d.ts"
```

However, the npm tarball does not include `types/index.d.ts`. It does include `dist/index.d.ts`, and `exports["."].types` already points to that published declaration file.

## Validation

I validated this with static package metadata checks only:

```sh
npm pack @duplojs/zod-accelerator@2.6.2 --ignore-scripts --json
```

Then I inspected the extracted tarball and confirmed:

- `package/package.json` has `"types": "./types/index.d.ts"`
- `package/types/index.d.ts` is missing
- `package/dist/index.d.ts` exists
- `exports["."].types` already points to `./dist/index.d.ts`

No package scripts were run.
