### PR TITLE
fix: point types field at published declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:lint:fix": "eslint --fix",
     "prepare": "husky"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- update the top-level `types` field to `./dist/index.d.ts`
- align it with `exports["."].types` and the files published in the npm tarball

## Validation
- inspected `@duplojs/zod-accelerator@2.6.2` with `npm pack --ignore-scripts`: `types/index.d.ts` is missing while `dist/index.d.ts` is present
- `node -e` check confirmed package metadata now points `types` and `exports["."].types` to the same declaration file